### PR TITLE
Add jq parsing for item_id to CSV

### DIFF
--- a/pocket2csv
+++ b/pocket2csv
@@ -130,6 +130,7 @@ if .tags == null
  .tags = .tags 
  end
 ' \
+| jq '.item_id = (.item_id | tonumber)' \
 | jq '.favorite = (.favorite | tonumber)' \
 | jq '.has_video = (.has_video | tonumber)' \
 | jq '.has_image = (.has_image | tonumber)' \
@@ -157,6 +158,7 @@ if .tags == null
 | jq '.excerpt = (.excerpt | gsub("[\\n\\t]"; ""))' \
 | jq '.given_title = (.given_title | gsub("[\\n\\t]"; ""))' \
 | jq '{
+item_id: .item_id,
 time_added: .time_added,
 year_added: .year_added,
 month_added: .month_added,


### PR DESCRIPTION
This pull request introduces the following changes to the `pocket2csv` script:

- **Feature:** Modify the script to use `jq` for parsing `item_id` from `bookmarks.json`.
- **Enhancement:** Update intermediate file handling to accommodate the new `item_id` column.
- **Improvement:** Insert `item_id` as the first column in the CSV data.

These changes aim to enhance the pocket2csv tool to include parsing and exporting the item_id to the CSV output, addressing user needs for more detailed item tracking and identification.

**Testing:**

- Verified the script runs successfully with the updated parsing logic.
- Confirmed the `item_id` is correctly inserted as the first column in the output CSV.

**Notes:**

- Ensure `jq` is installed and available in the environment where the script is executed.
- Review and test the changes thoroughly to confirm compatibility with existing workflows.